### PR TITLE
docs : agrego trazabilidad completa con enlaces a issues y pull requests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,3 +13,30 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.
 ### Changed
 - **Arquitectura:** Se movió el archivo `changelog.md` a la raíz del repositorio según la sección 4.2 de la consigna.
 - **Normalización:** Renombrado de carpeta `Anexo/` a `anexos/` para cumplir con el estándar de minúsculas.
+
+---
+
+## Trazabilidad del trabajo
+
+### Natalia Carreras - Documentadora
+- Issue: https://github.com/nataliacarreras96git/SistemaTurnosMedicos/issues/7
+- Pull Request: https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/12
+- Tarea: Creación y estructuración del README, redacción de introducción (incluyendo fundamentos de POO) e incorporación de anexos.
+
+### Agustín De Marco - Modelador de Casos de Uso
+- Issue: https://github.com/nataliacarreras96git/SistemaTurnosMedicos/issues/1
+- Pull Request: https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/6
+              : https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/10
+              : https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/11
+              : https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/13
+- Tarea: Modelado y documentación de los casos de uso principales del sistema.
+
+### Luciano Barrionuevo - Diseñador de Clases
+- Issue: https://github.com/nataliacarreras96git/SistemaTurnosMedicos/issues/5
+- Pull Request: https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/9
+- Tarea: Diseño del diagrama de clases en formato .excalidraw, .png y .puml.
+
+### Ignacio Nervi - Analista de Requerimientos
+- Issue: https://github.com/nataliacarreras96git/SistemaTurnosMedicos/issues/2
+- Pull Request: https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/8
+- Tarea: Análisis de información y definición de requisitos funcionales (RF) y no funcionales (RNF).


### PR DESCRIPTION
Se incorpora sección de trazabilidad del trabajo incluyendo roles, issues y pull requests de cada integrante, cumpliendo con los requisitos de la cátedra.