### PR TITLE
fix: agregar templates de PR requeridos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature_branch.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_branch.md
@@ -1,0 +1,52 @@
+## 📋 Descripción de la Feature
+
+<!-- Descripción breve de qué hace esta feature y por qué es importante -->
+
+### Tipo de cambio
+
+- [ ] ✨ Nueva feature/funcionalidad
+- [ ] 🐛 Corrección de bug
+- [ ] 📚 Documentación
+- [ ] ♻️ Refactorización
+- [ ] ⚙️ Configuración/Dependencias
+
+## 🎯 Requisitos completados
+
+<!-- Marca los requisitos que se cumplen en esta feature -->
+
+- [ ] Requisito Funcional (RF)
+- [ ] Requisito No Funcional (RNF)
+- [ ] Caso de Uso (CU)
+
+### Descripción de cambios
+
+<!-- Lista los cambios principales realizados -->
+
+- 
+- 
+- 
+
+## ✅ Checklist
+
+- [ ] Código sigue las convenciones del proyecto
+- [ ] Tests (si aplica) han sido agregados/actualizados
+- [ ] Documentación actualizada
+- [ ] Sin conflictos con la rama base (develop)
+- [ ] Commits tienen mensajes claros
+
+## 📸 Screenshots/Evidencia (si aplica)
+
+<!-- Adjunta screenshots o capturas que demuestren la feature en funcionamiento -->
+
+## 🔗 Referencias
+
+<!-- Links a issues, requisitos, o documentación relacionada -->
+
+- Cierra #(issue number si aplica)
+- Relacionado a: [Requisito/Documentación]
+
+---
+
+**Autor:** @{username}  
+**Rama:** `feature/{nombre-de-la-feature}`  
+**Base:** `develop`

--- a/.github/PULL_REQUEST_TEMPLATE/release_branch.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_branch.md
@@ -1,0 +1,76 @@
+## 🚀 Release - Actividad Obligatoria
+
+<!-- Descripción de la versión/entrega -->
+
+### Versión
+<!-- Ej: Actividad Obligatoria N°1, Sprint 2, Release v1.0.0 -->
+
+## 📋 Cambios incluidos en esta release
+
+### ✨ Nuevas features
+<!-- Enumera las nuevas funcionalidades agregadas -->
+
+- 
+- 
+- 
+
+### 🔧 Cambios técnicos
+<!-- Cambios en código, estructura, configuración -->
+
+- 
+- 
+- 
+
+### 🐛 Bugs corregidos
+<!-- Correcciones de errores -->
+
+- 
+- 
+- 
+
+## ✅ Controles de calidad
+
+- [ ] Todos los tests pasan
+- [ ] Sin conflictos con base (master)
+- [ ] Changelog.md actualizado
+- [ ] Documentación completa
+- [ ] Código revisado por pares
+- [ ] Commits tienen mensajes claros
+
+## 📚 Documentación y Referencias
+
+### Historias de usuario/Requisitos cumplidos
+<!-- Referencias a RFs, RNFs, CUs, Issues -->
+
+- [ ] RF1 - 
+- [ ] RF2 - 
+- [ ] RNF1 - 
+- [ ] CU1 - 
+
+### Archivos modificados claves
+<!-- Principales cambios de estructura/contenido -->
+
+- 
+- 
+- 
+
+## 🔄 Proceso de merge
+
+1. ✅ Rama creada desde: `release/actividad-obligatoria-1`
+2. ⏳ Objetivo: Merge a `master` para producción/entrega
+3. 📝 Cambios registrados en `changelog.md`
+
+## 👥 Información del equipo
+
+**Integrantes del grupo:**
+- [Nombre 1] - Rol
+- [Nombre 2] - Rol
+- [Nombre 3] - Rol
+
+**Reviewers requeridos:** @MVelasquez98 (Profesor)
+
+---
+
+**Estado:** Listo para revisión y merge a master  
+**Rama base:** `master`  
+**Rama origen:** `release/actividad-obligatoria-1`


### PR DESCRIPTION
Agregar templates de PR según requerimiento de la consigna:

- .github/PULL_REQUEST_TEMPLATE/feature_branch.md (para PRs de feature/ → develop)
- .github/PULL_REQUEST_TEMPLATE/release_branch.md (para PRs de release/ → master)

Estos templates serán usados por los colaboradores en posteriores actividades.