### PR TITLE
Create 04-tarjeta-crc-agenda.md

### DIFF
--- a/herramientas-agile/tarjetas-crc/04-tarjeta-crc-agenda.md
+++ b/herramientas-agile/tarjetas-crc/04-tarjeta-crc-agenda.md
@@ -1,0 +1,10 @@
+|   |   |   |   |
+|---|---|---|---|
+| **Nombre de la Clase:** | Agenda |   |   |
+| **Superclase:** |   |   |   |
+| **Subclase:** |   |   |   |
+| **Responsabilidades** | **Colaboradores** | **Pensamiento del objeto** | **Propiedad** |
+| Registrar disponibilidad de médicos | Medico, Secretaria | Muestro las horas disponibles | Listado de horarios |
+| Mostrar turnos programados | Turno | Tengo que poner todos los turnos asignados | Turnos asignados |
+| Permitir búsqueda de turnos | Secretaria | Permito buscar por fecha o médico | Filtros de búsqueda |
+|   |   |   |   |


### PR DESCRIPTION
Esta tarjeta CRC está dedicada a la clase Agenda, enfocándose en la organización de los horarios médicos, la interacción con otras clases y las propiedades cruciales para la gestión de turnos.