### PR TITLE
Create herramientas_agile.md

### DIFF
--- a/herramientas-agile/herramientas_agile.md
+++ b/herramientas-agile/herramientas_agile.md
@@ -1,0 +1,15 @@
+# Índice de Herramientas Agile
+
+Este documento contiene enlaces a las tarjetas CRC del sistema de turnos médicos.
+
+## Tarjetas CRC
+
+- [Paciente](tarjetas-crc/01-tarjeta-crc-paciente.md)
+- [Medico](tarjetas-crc/02-tarjeta-crc-medico.md)
+- [Turno](tarjetas-crc/03-tarjeta-crc-turno.md)
+- [Agenda](tarjetas-crc/04-tarjeta-crc-agenda.md)
+- [Secretaria](tarjetas-crc/05-tarjeta-crc-secretaria.md)
+
+---
+
+Cada archivo enlazado resume las responsabilidades, colaboradores y propiedades de la clase correspondiente, siguiendo el formato CRC.


### PR DESCRIPTION
Este archivo sirve como índice general de la carpeta de Herramientas Ágiles del proyecto. Contiene enlaces a cada una de las tarjetas CRC desarrolladas, facilitando el acceso y la navegación a la documentación de las clases principales del sistema de turnos médicos.

