### PR TITLE
Create 03-tarjeta-crc-turno.md

### DIFF
--- a/herramientas-agile/tarjetas-crc/03-tarjeta-crc-turno.md
+++ b/herramientas-agile/tarjetas-crc/03-tarjeta-crc-turno.md
@@ -1,0 +1,11 @@
+|   |   |   |   |
+|---|---|---|---|
+| **Nombre de la Clase:** | Turno |   |   |
+| **Superclase:** |   |   |   |
+| **Subclase:** |   |   |   |
+| **Responsabilidades** | **Colaboradores** | **Pensamiento del objeto** | **Propiedad** |
+| Registrar solicitud de turno | Paciente, Secretaria | Alguien quiere un turno médico | Fecha, Hora, Estado |
+| Asignar turno a paciente y médico | Paciente, Medico, Secretaria | Hay que definir a quién y cuándo se asigna | Paciente, Médico |
+| Modificar estado del turno | Secretaria, Paciente, Medico | El turno puede cambiar su estado | Estado (pendiente, confirmado, cancelado, realizado) |
+| Reprogramar turno | Secretaria, Paciente | Puede cambiar la fecha y hora | Nueva fecha, nueva hora |
+|   |   |   |   |


### PR DESCRIPTION
Esta tarjeta CRC corresponde a la clase Turno, detallando cómo se gestiona la asignación y modificación de turnos médicos, los colaboradores clave y las propiedades esenciales asociadas a cada turno.