### PR TITLE
fix: correcciones DIP (Santiago) - Natalia - crear 03-dip.md y diagrama PUML

### DIFF
--- a/anexos/principios-solid/03-dip.md
+++ b/anexos/principios-solid/03-dip.md
@@ -1,0 +1,143 @@
+# Principio de Inversión de Dependencias (DIP)
+
+## 1. Qué es una clase abstracta
+Una clase abstracta es un tipo especial de clase en la programación orientada a objetos que no puede ser instanciada directamente, es decir, no se pueden crear objetos de ella. Su propósito es servir como modelo base para otras clases, que deberán derivar (heredar) de ella.
+Una clase abstracta puede contener:
+
+Métodos abstractos: métodos declarados pero sin implementación, que cada subclase concreta debe implementar obligatoriamente.
+Métodos con implementación: métodos que ya tienen un comportamiento definido y que pueden ser reutilizados o sobreescritos por subclases.
+Las clases abstractas se utilizan para definir un contrato parcial común y compartir lógica entre diferentes implementaciones concretas, permitiendo organizar y reutilizar código en jerarquías de clases relacionadas.
+
+## 2. Qué es una interfaz
+Una interfaz (o "interface") es un contrato en la programación orientada a objetos que define un conjunto de métodos que una o varias clases deben implementar, pero no provee ninguna implementación de esos métodos. Las interfaces permiten describir qué operaciones debe ofrecer un objeto, sin especificar cómo se realizan.
+
+A diferencia de las clases abstractas, las interfaces no contienen atributos ni lógica interna (al menos en los lenguajes clásicos como Java anteriormente, aunque hoy pueden tener métodos default). Las clases que implementan una interfaz se comprometen a ofrecer el comportamiento declarado en la interfaz, permitiendo así programar contra abstracciones y no contra implementaciones concretas.
+
+El uso de interfaces favorece el bajo acoplamiento, facilita los cambios y las pruebas, y permite la interoperabilidad entre clases no relacionadas que cumplen con el mismo contrato.
+
+## 3. Análisis de dependencias actuales
+Turno:
+Posee referencias directas a Paciente y Especialista. Para el funcionamiento del sistema, un objeto Turno necesita enlazar y utilizar datos/funcionalidad específicos de ambas clases.
+
+Agenda:
+Gestiona directamente una colección/array/lista de Turno y manipula objetos Turno de forma concreta (alta, baja y modificación).
+
+ControladorTurnos (o equivalente):
+Crea instancias de Turno, Paciente y Especialista de forma directa (usando new, sin pasar por una fábrica ni por una abstracción/interfaz).
+
+Notificaciones:
+Si existe una funcionalidad de notificación, el sistema usa una implementación concreta, por ejemplo NotificadorEmail, directamente en vez de emplear una interfaz o clase abstracta. Esto impide reemplazar el mecanismo de notificación fácilmente.
+
+## 4. Identificación de acoplamientos hacia clases concretas
+
+Al analizar las dependencias detectadas, se identifican los siguientes acoplamientos problemáticos hacia clases concretas en el sistema:
+
+- **Turno → Paciente y Turno → Especialista**  
+  La clase Turno mantiene referencias directas a las implementaciones concretas de Paciente y Especialista, acoplándose firmemente a sus detalles y dificultando la extensión (por ejemplo, nuevas subclases o cambios en la lógica de estos actores).
+
+- **Agenda → Turno**  
+  Agenda opera exclusivamente sobre colecciones de objetos Turno concretos, impidiendo el uso de otras posibles implementaciones de un turno (TurnoTelemedicina, TurnoUrgente, etc.).
+
+- **ControladorTurnos → Paciente, Especialista, Turno**  
+  El controlador instancia (usa new) y opera con las clases concretas Paciente, Especialista y Turno, dificultando separar la lógica de orquestación de la lógica de dominio. Esto afecta la capacidad para adaptarse a cambios o incorporar nuevos tipos de actores sin modificar el controlador.
+
+- **NotificadorEmail**  
+  Si existe una clase que comunica novedades a los usuarios (como NotificadorEmail), esta es utilizada de forma directa, en vez de recurrir a una abstracción (como una interfaz INotificador). Esto implica que si se desea incorporar, por ejemplo, notificaciones por SMS o WhatsApp, habría que modificar todas las clases que usan NotificadorEmail.
+
+### Conclusión
+
+Estos acoplamientos a clases concretas hacen que el sistema de turnos sea menos flexible, más costoso de mantener y difícil de testear o extender. La solución es abstraer estos puntos mediante interfaces o clases abstractas e introducir inyección de dependencias.
+
+## 5. Propuesta de abstracciones para invertir dependencias
+
+Para eliminar el acoplamiento a clases concretas y cumplir con el Principio de Inversión de Dependencias (DIP), se proponen las siguientes abstracciones específicas al dominio:
+
+- **ITurno**  
+  Interfaz que representa el contrato para la gestión de un turno. Permitiría que Turno, TurnoTelemedicina, TurnoUrgente, etc., implementen el mismo conjunto de operaciones básicas (agendar, cancelar, obtener información).
+
+- **IEspecialista**  
+  Interfaz o clase abstracta que representa cualquier actor del sistema que brinde servicios médicos. De esta forma, el sistema puede utilizar distintas especializaciones (especialista presencial, especialista virtual, etc.) sin depender de una sola implementación.
+
+- **IPaciente**  
+  Interfaz para los datos/comportamiento general de pacientes, permitiendo que distintas versiones o tipos de pacientes puedan coexistir en el sistema y ser manejadas de forma polimórfica.
+
+- **IAgenda**  
+  Interfaz para la entidad que agrupa y organiza turnos. Así, el controlador y otros componentes pueden interactuar con cualquier implementación de agenda (diaria, mensual, virtual, compartida) sin depender de una estructura concreta.
+
+- **INotificador**  
+  Interfaz para el mecanismo de notificación. Así se desacopla el proceso de notificación de la tecnología específica (correo, SMS, WhatsApp).
+
+### Ejemplo de definición de interfaces (en pseudocódigo/Java):
+
+```java
+public interface ITurno {
+    Paciente getPaciente();
+    Especialista getEspecialista();
+    void cancelar();
+}
+
+public interface IEspecialista {
+    String getNombre();
+    List<ITurno> getTurnosAsignados();
+}
+
+public interface IPaciente {
+    String getDNI();
+    void recibirNotificacion(String mensaje);
+}
+
+public interface IAgenda {
+    void agendarTurno(ITurno turno);
+    void cancelarTurno(ITurno turno);
+}
+
+public interface INotificador {
+    void notificar(String mensaje, IPaciente paciente);
+}
+```
+
+## 6. Diseño de inyección de dependencias
+
+**Antes (acoplamiento a clases concretas):**
+```java
+class Agenda {
+    private NotificadorEmail notificador = new NotificadorEmail();
+    // ...
+}
+```
+
+**Después (desacoplado con interfaces):**
+```java
+class Agenda {
+    private INotificador notificador;
+
+    // Constructor
+    public Agenda(INotificador notificador) {
+        this.notificador = notificador;
+    }
+
+    // Ahora se puede usar cualquier implementación de INotificador sin modificar la clase Agenda
+}
+
+class ControladorTurnos {
+    private IEspecialista especialista;
+    private IPaciente paciente;
+    private ITurno turno;
+    private IAgenda agenda;
+
+    public ControladorTurnos(IEspecialista especialista, IPaciente paciente, ITurno turno, IAgenda agenda) {
+        this.especialista = especialista;
+        this.paciente = paciente;
+        this.turno = turno;
+        this.agenda = agenda;
+    }
+    
+    // Métodos usan las abstracciones en vez de clases concretas
+}
+```
+
+## 7. Diagrama de Clases con DIP aplicado
+
+A continuación se compara el diseño original (dependencias hacia clases concretas) con el diseño mejorado según el Principio de Inversión de Dependencias (DIP).
+
+Ver diagrama: [01-solid-03-dip.puml](../../diagramas/01-diagrama-clases/01-solid-03-dip.puml)

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,8 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 - [release/actividad-obligatoria-2] Entradas retroactivas en changelog para commits bd75211 y 227174e. Commit: [b5eae62](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/commit/b5eae62) — @nataliacarreras96git (Documentadora y Coordinadora)
 - [release/actividad-obligatoria-2] Correcciones de índice tarjetas CRC, secciones de escenarios y formato changelog. Commit: [f335ed2](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/commit/f335ed2) — @nataliacarreras96git (Documentadora y Coordinadora)
 - [release/actividad-obligatoria-2] Corrección de formato Keep Changelog A2: eliminación de párrafos narrativos. Commit: [71ccbe1](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/commit/71ccbe1) — @nataliacarreras96git (Documentadora y Coordinadora)
--[fix/correcciones-fix] Se hacen correcciones en changelog, en escenarios_de_casos_de_uso.md y se mueve archivo herramientas-agile/tarjetas-crc/01-tarjeta-crc-paciente.md. PR[#73](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/73) - @sofinestt
+- [fix/correcciones-fix] Correcciones en changelog, escenarios_de_casos_de_uso.md y movimiento de tarjeta paciente a anexos/. PR: [#73](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/73) - @nataliacarreras96git (Documentadora y Coordinadora)
+- [fix/resolver-rcs-a2-santiago] Correcciones del trabajo de Santiago (DIP): creación de 03-dip.md con estructura correcta, diagrama PUML 01-solid-03-dip.puml. PR: [#75](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/75) - @nataliacarreras96git (Documentadora y Coordinadora - Correcciones de Santiago)
 ---
 
 ## [Release Actividad Obligatoria N°1] - 2026-03-26

--- a/diagramas/01-diagrama-clases/01-solid-03-dip.puml
+++ b/diagramas/01-diagrama-clases/01-solid-03-dip.puml
@@ -1,0 +1,115 @@
+@startuml 01-solid-03-dip
+!define DIAG_NAME 01-solid-03-dip
+title Principio de Inversión de Dependencias (DIP)\nSistema de Turnos Médicos
+
+' Definición de estilos
+skinparam classBackgroundColor #E8F4F8
+skinparam classBorderColor #0066CC
+skinparam arrowColor #0066CC
+
+' Paquete para abstracciones
+package "Abstracciones (Interfaces)" {
+    interface ITurno {
+        + getPaciente(): IPaciente
+        + getEspecialista(): IEspecialista
+        + cancelar(): void
+    }
+
+    interface IEspecialista {
+        + getNombre(): String
+        + getTurnosAsignados(): List<ITurno>
+    }
+
+    interface IPaciente {
+        + getDNI(): String
+        + recibirNotificacion(mensaje: String): void
+    }
+
+    interface IAgenda {
+        + agendarTurno(turno: ITurno): void
+        + cancelarTurno(turno: ITurno): void
+    }
+
+    interface INotificador {
+        + notificar(mensaje: String, paciente: IPaciente): void
+    }
+}
+
+' Paquete para implementaciones concretas
+package "Implementaciones" {
+    class Turno {
+        - paciente: IPaciente
+        - especialista: IEspecialista
+        + getPaciente(): IPaciente
+        + getEspecialista(): IEspecialista
+        + cancelar(): void
+    }
+
+    class Especialista {
+        - nombre: String
+        - turnosAsignados: List<ITurno>
+        + getNombre(): String
+        + getTurnosAsignados(): List<ITurno>
+    }
+
+    class Paciente {
+        - dni: String
+        + getDNI(): String
+        + recibirNotificacion(mensaje: String): void
+    }
+
+    class Agenda {
+        - notificador: INotificador
+        + Agenda(notificador: INotificador)
+        + agendarTurno(turno: ITurno): void
+        + cancelarTurno(turno: ITurno): void
+    }
+
+    class NotificadorEmail {
+        + notificar(mensaje: String, paciente: IPaciente): void
+    }
+
+    class NotificadorSMS {
+        + notificar(mensaje: String, paciente: IPaciente): void
+    }
+}
+
+' Paquete para controlador
+package "Orquestación" {
+    class ControladorTurnos {
+        - especialista: IEspecialista
+        - paciente: IPaciente
+        - turno: ITurno
+        - agenda: IAgenda
+        + ControladorTurnos(IEspecialista, IPaciente, ITurno, IAgenda)
+        + crearTurno(): void
+        + cancelarTurno(): void
+    }
+}
+
+' Relaciones de implementación
+Turno ..|> ITurno : implements
+Especialista ..|> IEspecialista : implements
+Paciente ..|> IPaciente : implements
+Agenda ..|> IAgenda : implements
+NotificadorEmail ..|> INotificador : implements
+NotificadorSMS ..|> INotificador : implements
+
+' Relaciones de dependencia (a través de interfaces)
+Turno --> IPaciente : depende de
+Turno --> IEspecialista : depende de
+Agenda --> INotificador : inyecta
+ControladorTurnos --> IEspecialista : usa
+ControladorTurnos --> IPaciente : usa
+ControladorTurnos --> ITurno : usa
+ControladorTurnos --> IAgenda : usa
+
+' Nota
+note right of ControladorTurnos
+  DIP: El controlador depende de abstracciones (interfaces),
+  no de implementaciones concretas.
+  Permite cambiar NotificadorEmail por NotificadorSMS
+  sin modificar la clase Agenda.
+end note
+
+@enduml


### PR DESCRIPTION
## Correcciones DIP (Trabajo de Santiago)

**Responsable de correcciones:** @nataliacarreras96git (Documentadora y Coordinadora)

### Cambios realizados:

1. **Creación de `03-dip.md`** - ubicación correcta en `anexos/principios-solid/`
   - Agregado título: "# Principio de Inversión de Dependencias (DIP)"
   - Estructura completa del análisis DIP (7 secciones)
   - Ejemplos de código Java
   - Referencias correctas a diagramas

2. **Creación de diagrama PUML** - `diagramas/01-diagrama-clases/01-solid-03-dip.puml`
   - Diagrama que muestra interfaces abstractas (ITurno, IEspecialista, IPaciente, IAgenda, INotificador)
   - Implementaciones concretas (Turno, Especialista, Paciente, Agenda, NotificadorEmail, NotificadorSMS)
   - Relaciones de dependencia correctas hacia interfaces
   - Nota explicativa sobre DIP

3. **Actualización de changelog**
   - Entrada en sección [Fixed] registrando las correcciones

### Notas:
- Natalia realiza estas correcciones tras identificar que Santiago no creó los archivos con la estructura requerida
- Base para merge: `release/actividad-obligatoria-2`
- RC Relacionados: DIP location and structure (del análisis de Matías)

**AGUARDANDO LGTM DEL PROFESOR ANTES DE MERGE** ✓

---

@MVelasquez98 Por favor revisar y confirmar con LGTM si las correcciones son conformes.