### PR TITLE
correcciones del changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 - [release/actividad-obligatoria-2] Corrección de formato Keep Changelog A2: eliminación de párrafos narrativos. Commit: [71ccbe1](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/commit/71ccbe1) — @nataliacarreras96git (Documentadora y Coordinadora)
 - [fix/correcciones-fix] Correcciones en changelog, escenarios_de_casos_de_uso.md y movimiento de tarjeta paciente a anexos/. PR: [#73](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/73) - @nataliacarreras96git (Documentadora y Coordinadora)
 - [fix/resolver-rcs-a2-changelog]  Correccion de entradas en changelog con [#?] placeholder en ### Added y entrada en ### Changed sin PR link. Correccion de formato de PRs. PR [#78](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/78) - @nataliacarreras96git (Documentadora y Coordinadora)
+- [fix/correcciones-changelog-fix] Se elimina entrada de changelog de la parte "Changed" al ser texto plano y no corresponder a ninguna PR, se eliminan entradas de PRs #75 y #76 del changelog ya que correspondían a correcciones del parcial, se agrega entrada de PR #78. PR [#79] - @sofinestt 
 
 
 ## [Release Actividad Obligatoria N°1] - 2026-03-26

--- a/changelog.md
+++ b/changelog.md
@@ -19,8 +19,6 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 
 ### Changed
 
-- [release/actividad-obligatoria-2] Preparación de rama release para entrega: rama creada desde develop, integración de todos los cambios A2 listos para evaluación profesor, README.md completamente reescrito, changelog.md actualizado con sección [Released - A2], todos los artefactos accesibles y bien documentados. @nataliacarreras96git (Coordinadora)
-
 ### Fixed
 
 - [release/actividad-obligatoria-2] Correcciones RC1–RC11 solicitadas en review: tarjeta paciente en release, escenarios a 4 tablas, índices, cancelar-turno <<include>>, documentación IA con triple backtick. Commit: [bd75211](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/commit/bd75211) - @nataliacarreras96git (Documentadora y Coordinadora)
@@ -29,11 +27,8 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
 - [release/actividad-obligatoria-2] Correcciones de índice tarjetas CRC, secciones de escenarios y formato changelog. Commit: [f335ed2](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/commit/f335ed2) — @nataliacarreras96git (Documentadora y Coordinadora)
 - [release/actividad-obligatoria-2] Corrección de formato Keep Changelog A2: eliminación de párrafos narrativos. Commit: [71ccbe1](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/commit/71ccbe1) — @nataliacarreras96git (Documentadora y Coordinadora)
 - [fix/correcciones-fix] Correcciones en changelog, escenarios_de_casos_de_uso.md y movimiento de tarjeta paciente a anexos/. PR: [#73](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/73) - @nataliacarreras96git (Documentadora y Coordinadora)
-- [fix/resolver-rcs-a2-santiago] Correcciones del trabajo de Santiago (DIP): creación de 03-dip.md con estructura correcta, diagrama PUML 01-solid-03-dip.puml. PR: [#75](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/75) - @nataliacarreras96git (Documentadora y Coordinadora - Correcciones de Santiago)
-- [fix/resolver-rcs-a2-tomas] Creación de 01-srp.md: análisis del Principio de Responsabilidad Única con ejemplos Sistema de Turnos. PR: [#76](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/76) - @nataliacarreras96git (Documentadora y Coordinadora - SRP que faltaba)
-- [fix/resolver-rcs-a2-tomas] Creación de 02-ocp.md: análisis del Principio Abierto/Cerrado con patrones de extensión. PR: [#76](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/76) - @nataliacarreras96git (Documentadora y Coordinadora - OCP de Tomás)
-- [fix/resolver-rcs-a2-tomas] Creación de 05-lsp.md: análisis del Principio de Sustitución de Liskov con jerarquías de turnos. PR: [#76](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/76) - @nataliacarreras96git (Documentadora y Coordinadora - LSP de Tomás)
----
+- [fix/resolver-rcs-a2-changelog]  Correccion de entradas en changelog con [#?] placeholder en ### Added y entrada en ### Changed sin PR link. Correccion de formato de PRs. PR [#78](https://github.com/nataliacarreras96git/SistemaTurnosMedicos/pull/78) - @nataliacarreras96git (Documentadora y Coordinadora)
+
 
 ## [Release Actividad Obligatoria N°1] - 2026-03-26
 


### PR DESCRIPTION
Se elimina entrada de changelog de la parte "Changed" al ser texto plano y no corresponder a ninguna PR
Se eliminan entradas de PRs #75 y #76 del changelog ya que correspondían a correcciones del parcial
Se agrega entrada de PR #78 