### PR TITLE
Fix/reprogramar turno correcciones 1

### DIFF
--- a/anexos/analisis-funcional/02-caso-de-uso-reprogramar-turno.md
+++ b/anexos/analisis-funcional/02-caso-de-uso-reprogramar-turno.md
@@ -90,11 +90,14 @@
 
 | Clase | Responsabilidad (según tarjeta CRC) | Tarjeta CRC |
 |-------|-------------------------------------|-------------|
-| Paciente | Solicitar turno médico | ../../herramientas-agile/tarjetas-crc/01-tarjeta-crc-paciente.md |
-| Medico | Modificar disponibilidad | ../../herramientas-agile/tarjetas-crc/02-tarjeta-crc-medico.md |
-| Turno | Reprogramar turno y modificar estado del turno | ../../herramientas-agile/tarjetas-crc/03-tarjeta-crc-turno.md |
-| Agenda | Permitir búsqueda de turnos y mostrar turnos programados | ../../herramientas-agile/tarjetas-crc/04-tarjeta-crc-agenda.md |
-| Secretaria | Gestionar turnos (reprogramar) | ../../herramientas-agile/tarjetas-crc/05-tarjeta-crc-secretaria.md |
+| Paciente | Solicitar turno médico | [link al archivo md](../../herramientas-agile/tarjetas-crc/01-tarjeta-crc-paciente.md) |
+| Medico | Modificar disponibilidad | [link al archivo md](../../herramientas-agile/tarjetas-crc/02-tarjeta-crc-medico.md) |
+| Turno | Reprogramar turno y modificar estado del turno | [link al archivo md](../../herramientas-agile/tarjetas-crc/03-tarjeta-crc-turno.md) |
+| Agenda | Permitir búsqueda de turnos y mostrar turnos programados | [link al archivo md](../../herramientas-agile/tarjetas-crc/04-tarjeta-crc-agenda.md) |
+| Secretaria | Gestionar turnos (reprogramar) | [link al archivo md](../../herramientas-agile/tarjetas-crc/05-tarjeta-crc-secretaria.md) |
+| UsuarioDelSistema | Autenticar y actualizar datos | [link al archivo md](../../herramientas-agile/tarjetas-crc/06-tarjeta-crc-usuariodelsistema.md) |
+| Auditoria | Registrar cambios y eventos | [link al archivo md](../../herramientas-agile/tarjetas-crc/08-tarjeta-crc-auditoria.md) |
+| Notificacion | Enviar notificacion | [link al archivo md](../../herramientas-agile/tarjetas-crc/07-tarjeta-crc-notificacion.md) |
 
 **Relaciones UML:**
 
@@ -107,7 +110,7 @@
 | Dependencia | Secretaria → Medico | La secretaria consulta la disponibilidad del médico antes de confirmar el cambio. |
 | Dependencia | Secretaria → Turno | La secretaria interactúa con el turno para ejecutar la reprogramación. |
 | Agregación | Agenda → Turno | La agenda administra múltiples turnos sin controlar completamente su ciclo de vida. |
-| Composición | Agenda → Historial | El historial forma parte de la agenda y depende de ella para existir. |
+| Composición | Agenda → Auditoria | Auditoria forma parte de la agenda y depende de ella para existir. |
 | Dependencia | Agenda → Notificacion | La agenda utiliza el servicio de notificaciones para informar cambios. |
 | Asociación | Turno → Paciente | Cada turno se encuentra asociado a un paciente. |
 | Asociación | Turno → Medico | Cada turno se encuentra asociado a un médico. |
@@ -139,10 +142,10 @@ SI resultado es válido
     turno.cambiarEstado("Reprogramado")
 
     // Se registra la modificación para mantener trazabilidad
-    agenda.registrarEnHistorial("Secretaria", "Reprogramación de turno")
+    auditoria.guardarEvento("Secretaria", "Reprogramación de turno")
 
     // Se informa al paciente el nuevo horario asignado
-    agenda.enviarNotificacion(paciente, "Turno reprogramado")
+    notificacion.enviar(paciente, "Turno reprogramado")
 SINO
     // Se detecta un conflicto y se ofrecen horarios alternativos
     alternativas = agenda.sugerirHorariosAlternativos(nuevoHorario)
@@ -150,8 +153,8 @@ SINO
     SI usuario selecciona una alternativa de la lista
         turno.actualizarTurno(alternativaSeleccionada)
         turno.cambiarEstado("Reprogramado")
-        agenda.registrarEnHistorial("Secretaria", "Reprogramación de turno")
-        agenda.enviarNotificacion(paciente, "Turno reprogramado")
+        auditoria.guardarEvento("Secretaria", "Reprogramación de turno")
+        notificacion.enviar(paciente, "Turno reprogramado")
     SINO
         // Flujo alternativo: usuario no selecciona alternativa
         Retornar "Reprogramación cancelada - sin cambios"

--- a/anexos/analisis-funcional/happy-path-global.md
+++ b/anexos/analisis-funcional/happy-path-global.md
@@ -26,7 +26,7 @@ SI (disponible == VERDADERO) ENTONCES
     turno.cambiarEstado(TurnoEstado.CONFIRMADO)
     
     // Registrar en historial y notificar
-    agenda.registrarEnHistorial(turno.id, "Turno creado y confirmado")
+    auditoria.guardarEvento(turno.id, "Turno creado y confirmado")
     paciente.recibirNotificacion("Su turno ha sido confirmado para el 30/06 a las 10:00")
     
     ESCRIBIR "Turno creado: " + turno.id + " - Estado: CONFIRMADO"
@@ -50,7 +50,7 @@ boolean reprogramado = turno.reprogramar(nuevaFechaHora)
 
 SI (reprogramado == VERDADERO) ENTONCES
     turno.cambiarEstado(TurnoEstado.REPROGRAMADO)
-    agenda.registrarEnHistorial(turno.id, "Turno reprogramado al " + nuevaFechaHora)
+    auditoria.guardarEvento(turno.id, "Turno reprogramado al " + nuevaFechaHora)
     paciente.recibirNotificacion("Su turno fue reprogramado para las 14:00")
     
     ESCRIBIR "Turno reprogramado exitosamente"
@@ -79,7 +79,7 @@ medico.registrarObservacion(turno.id, "Paciente presenta presión arterial norma
 
 // Marcar el turno como realizado
 turno.cambiarEstado(TurnoEstado.REALIZADO)
-agenda.registrarEnHistorial(turno.id, "Turno realizado - Atención completada")
+auditoria.guardarEvento(turno.id, "Turno realizado - Atención completada")
 
 ESCRIBIR "Atención finalizada. Turno " + turno.id + " marcado como REALIZADO"
 


### PR DESCRIPTION
- Se corrigieron palabras y se agregaron clases en el análisis de reprogramar turno
- Se renombraron clases y métodos del happy path global para una mejor coherencia de datos